### PR TITLE
Previews/content of external URLs part of changes for #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This readme is also available [in Russian](README.ru.md).
 
 ```shell
 pip install aiogram
+pip install beautifulsoup4
+pip install lxml
 ```
 
 3. Install Whisper module if you need voice messages get recognized to text (you need [git](https://git-scm.com/) installed to be able to do this):

--- a/README.ru.md
+++ b/README.ru.md
@@ -30,6 +30,8 @@
 
 ```shell
 pip install aiogram
+pip install beautifulsoup4
+pip install lxml
 ```
 
 3. Если требуется распознавать голосовые сообщения, установите модуль Whisper (для его установки в системе должен быть установлен [git](https://git-scm.com/)):

--- a/config.py
+++ b/config.py
@@ -11,6 +11,11 @@ photo_path = r'C:\your-obsidian-vault\attachments'
 # If False, messages will be saved as plain text. This also removes inline links.
 format_messages = True
 
+#if True, callout block containing link information such as description and/or image will be created
+# for messages containing single url
+#if False, or more than one url in the message, no callout will be created
+create_link_info = True
+
 # If True, voice messages will be recognized to text.
 # This requires Whisper ( https://github.com/openai/whisper ), FFMPEG, Python and PyTorch to be installed
 # on the machine where the script is running.

--- a/tg2obsidian_bot.py
+++ b/tg2obsidian_bot.py
@@ -282,6 +282,8 @@ def format_messages() -> bool:
     format_messages = True if 'format_messages' not in dir(config) or config.format_messages else False
     return format_messages
 
+def create_link_info() -> bool:
+    return False if 'create_link_info' not in dir(config) else config.create_link_info
 
 def save_message(note: str) -> None:
     curr_date = dt.now().strftime('%Y-%m-%d')
@@ -408,7 +410,7 @@ def parse_entities(text: bytes,
         formatted_note += from_u16(text[offset:end])
     return formatted_note
 
-def is_url_only(message: Message) -> bool:
+def is_single_url(message: Message) -> bool:
     # assuming there is atleast one entity
     entities = message['entities']
     url_entity = entities[0]
@@ -483,7 +485,7 @@ async def embed_formatting(message: Message) -> str:
     try:
         note_u16 = to_u16(note)
         formatted_note = parse_entities(note_u16, entities, 0, len(note_u16))
-        if is_url_only(message):
+        if create_link_info() and is_single_url(message):
             url_entity = entities[0]
             url = url_entity.get_text(note) if url_entity['type'] == "url" else url_entity['url']
             formatted_note += await get_url_info_formatting(url)

--- a/tg2obsidian_bot.py
+++ b/tg2obsidian_bot.py
@@ -455,7 +455,16 @@ async def get_url_info_formatting(url: str) -> str:
                 if 'image' in og_props:
                     formatted_note += "\n>"
             if 'image' in og_props:
-                formatted_note += f"\n> ![]({og_props['image']})"
+                formatted_note += "\n> !["
+                if 'image:alt' in og_props:
+                   formatted_note += og_props['image:alt'].replace("\n", " ")
+                size_sep = "|"
+                if 'image:width' in og_props:
+                    formatted_note += f"|{og_props['image:width']}"
+                    size_sep = "x"
+                if 'image:height' in og_props:
+                    formatted_note += f"{size_sep}{og_props['image:height']}"
+                formatted_note += f"]({og_props['image']})"
             return formatted_note + "\n"
         return ''
 

--- a/tg2obsidian_bot.py
+++ b/tg2obsidian_bot.py
@@ -433,6 +433,10 @@ def get_open_graph_props(page: str) -> dict:
     meta = soup.find_all("meta", property=lambda x: x is not None and x.startswith("og:"))
     for m in meta:
         props[m['property'][3:].lstrip()] = m['content']
+    if not 'description' in props:
+        m = soup.find("meta", attrs={"name": "description"})
+        if m:
+            props['description'] = m['content']
     return props
 
 async def get_url_info_formatting(url: str) -> str:

--- a/tg2obsidian_bot.py
+++ b/tg2obsidian_bot.py
@@ -450,7 +450,8 @@ async def get_url_info_formatting(url: str) -> str:
             if 'title' in og_props:
                 formatted_note += "\n> # " + og_props['title']
             if 'description' in og_props:
-                formatted_note += "\n> " + og_props['description']
+                formatted_note += "\n> "
+                formatted_note += "\n> ".join(og_props['description'].split('\n'))
                 if 'image' in og_props:
                     formatted_note += "\n>"
             if 'image' in og_props:


### PR DESCRIPTION
Hi @dimonier,

Regarding #4, I guess telegram uses https://ogp.me/ metadata for page preview. I did some preliminary changes to support it.
If page contains og:description and/or og:image properties I create the following callout:

```
> [!link info] [(og:site_name)](url)
> # og:title
> og:description
> ![](og:image)
```
It is possible that namespace prefix could be not 'og' but I would not bother about it at least for now.
I guess user should be able to exclude this preview and format of this block is also discutable.
I added additional dependencies for this: `beautifulsoup4` and `lxml` (python hml parser is not that good).
I don't think I'm going to touch template/logic part of the issue.
